### PR TITLE
Revisit the name mangling rule usage for the '$' character (method and filenames named differently)

### DIFF
--- a/plugin/src/main/java/com/github/sbt/jni/javah/ClassName.java
+++ b/plugin/src/main/java/com/github/sbt/jni/javah/ClassName.java
@@ -9,6 +9,7 @@ public final class ClassName {
     private final String className;
     private final String simpleName;
     private final String mangledName;
+    private final String mangledHeaderName;
 
     public static ClassName of(String moduleName, String className) {
         Objects.requireNonNull(className, "Class name is null");
@@ -43,6 +44,7 @@ public final class ClassName {
         this.className = className;
         this.simpleName = className.substring(className.lastIndexOf('.') + 1);
         this.mangledName = mangleName(className);
+        this.mangledHeaderName = mangleHeaderName(className);
     }
 
     @Override
@@ -82,6 +84,10 @@ public final class ClassName {
 
     public final String mangledName() {
         return mangledName;
+    }
+
+    public final String mangledHeaderName() {
+        return mangledHeaderName;
     }
 
     public final String relativePath() {

--- a/plugin/src/main/java/com/github/sbt/jni/javah/util/JNIGenerator.java
+++ b/plugin/src/main/java/com/github/sbt/jni/javah/util/JNIGenerator.java
@@ -56,7 +56,7 @@ public class JNIGenerator {
                 return;
             }
         }
-        Path op = outputDir.resolve(name.mangledName() + ".h");
+        Path op = outputDir.resolve(name.mangledHeaderName() + ".h");
         try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(op))) {
             generateTo(name, out);
         } catch (Exception ex) {

--- a/plugin/src/main/java/com/github/sbt/jni/javah/util/Utils.java
+++ b/plugin/src/main/java/com/github/sbt/jni/javah/util/Utils.java
@@ -53,8 +53,6 @@ public final class Utils {
             char ch = name.charAt(i);
             if (ch == '.') {
                 builder.append('_');
-            } else if (ch == '$') {
-                builder.append("__");
             } else if (ch == '_') {
                 builder.append("_1");
             } else if (ch == ';') {

--- a/plugin/src/main/java/com/github/sbt/jni/javah/util/Utils.java
+++ b/plugin/src/main/java/com/github/sbt/jni/javah/util/Utils.java
@@ -46,23 +46,41 @@ public final class Utils {
         }
     });
 
+    public static String mangleChar(char ch) {
+        if (ch == '.') {
+            return "_";
+        } else if (ch == '_') {
+            return "_1";
+        } else if (ch == ';') {
+            return "_2";
+        } else if (ch == '[') {
+            return "_3";
+        } else if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && (ch <= 'Z'))) {
+            return String.valueOf(ch);
+        } else {
+            return String.format("_0%04x", (int) ch);
+        }
+    }
+
     public static String mangleName(String name) {
         StringBuilder builder = new StringBuilder(name.length() * 2);
         int len = name.length();
         for (int i = 0; i < len; i++) {
             char ch = name.charAt(i);
-            if (ch == '.') {
-                builder.append('_');
-            } else if (ch == '_') {
-                builder.append("_1");
-            } else if (ch == ';') {
-                builder.append("_2");
-            } else if (ch == '[') {
-                builder.append("_3");
-            } else if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && (ch <= 'Z'))) {
-                builder.append(ch);
+            builder.append(mangleChar(ch));
+        }
+        return builder.toString();
+    }
+
+    public static String mangleHeaderName(String name) {
+        StringBuilder builder = new StringBuilder(name.length() * 2);
+        int len = name.length();
+        for (int i = 0; i < len; i++) {
+            char ch = name.charAt(i);
+            if (ch == '$') {
+                builder.append("__");
             } else {
-                builder.append(String.format("_0%04x", (int) ch));
+                builder.append(mangleChar(ch));
             }
         }
         return builder.toString();


### PR DESCRIPTION
@jodersky also [mentioned](https://github.com/sbt/sbt-jni/issues/36#issuecomment-886038832) that it works [here](https://github.com/jodersky/mill-jnilib/blob/master/jnilib/src/jnilib/gjavah.scala) without extra rules for `$`. 

This PR is made to check what's going on with the header functions generation.

Closes https://github.com/sbt/sbt-jni/issues/36 (eventually)

### Context

JDK8 javah preserves a specific file naming when dealing with generating methods for Scala objects. It generates filenames for objects that contain `$` (all Scala objects)  as `package_ObjectName__.h` (mangles `$` into `__`). However, methods mangling is a bit different and for all methods it converts `$` into `_00024`.

Right now in the master branch, for the following `Adder.scala`:

```scala
package multiclasses

object Adder {

  @native def sum(term1: Int, term2: Int): Int

}
```

The following `multiclasses_Adder__.h` would be generated:

```c
/* DO NOT EDIT THIS FILE - it is machine generated */
#include <jni.h>
/* Header for class multiclasses_Adder__ */

#ifndef _Included_multiclasses_Adder__
#define _Included_multiclasses_Adder__
#ifdef __cplusplus
extern "C" {
#endif
/*
 * Class:      multiclasses_Adder__
 * Method:     sum
 * Signature:  (II)I
 */
 // An incorrect method name is generated!
JNIEXPORT jint JNICALL Java_multiclasses_Adder___sum
  (JNIEnv *, jobject, jint, jint);

#ifdef __cplusplus
}
#endif
#endif
```

With this PR the following `multiclasses_Adder__.h` would be generated:

```c
/* DO NOT EDIT THIS FILE - it is machine generated */
#include <jni.h>
/* Header for class multiclasses_Adder_00024 */

#ifndef _Included_multiclasses_Adder_00024
#define _Included_multiclasses_Adder_00024
#ifdef __cplusplus
extern "C" {
#endif
/*
 * Class:      multiclasses_Adder_00024
 * Method:     sum
 * Signature:  (II)I
 */
JNIEXPORT jint JNICALL Java_multiclasses_Adder_00024_sum
  (JNIEnv *, jobject, jint, jint);

#ifdef __cplusplus
}
#endif
#endif
```

cc @jodersky do we need to preserve the original jdk8 javah filename?
The alternative can be just to remove a special case around `$` and use the new namings generated by gjavah: `multiclasses_Adder_00024.h` which can be a bit more obvious (i.e. I would expect `multiclasses_Adder_00024` methods to be stored in a `multiclasses_Adder_00024.h` file).

TLDR; the whole difference in behavior is in this diff: https://github.com/pomadchin/sbt-jni/commit/ea4ecc86fea29c3b4b99bc4dfa5f25b42b6e78ac