### PR TITLE
Revisit the name mangling rule usage for the '$' character 

### DIFF
--- a/plugin/src/main/java/com/github/sbt/jni/javah/util/Utils.java
+++ b/plugin/src/main/java/com/github/sbt/jni/javah/util/Utils.java
@@ -53,8 +53,6 @@ public final class Utils {
             char ch = name.charAt(i);
             if (ch == '.') {
                 builder.append('_');
-            } else if (ch == '$') {
-                builder.append("__");
             } else if (ch == '_') {
                 builder.append("_1");
             } else if (ch == ';') {

--- a/plugin/src/sbt-test/sbt-jni/multiclasses/native1/src/library.c
+++ b/plugin/src/sbt-test/sbt-jni/multiclasses/native1/src/library.c
@@ -1,6 +1,6 @@
 #include <jni.h>
 #include "multiclasses_Adder.h"
-#include "multiclasses_Adder__.h"
+#include "multiclasses_Adder_00024.h"
 
 /*
  * Class:     multiclasses_Adder

--- a/plugin/src/sbt-test/sbt-jni/oneproject/test
+++ b/plugin/src/sbt-test/sbt-jni/oneproject/test
@@ -1,4 +1,4 @@
 > +javah
-$ exists src/native/include/simple_Library__.h
+$ exists src/native/include/simple_Library_00024.h
 > nativeInit cmake demo
 > +run

--- a/plugin/src/sbt-test/sbt-jni/simple-syntax/test
+++ b/plugin/src/sbt-test/sbt-jni/simple-syntax/test
@@ -1,5 +1,5 @@
 > +javah
-$ exists native/src/include/simple_Library__.h
+$ exists native/src/include/simple_Library_00024.h
 > nativeInit cmake demo
 > +test
 > +core/run

--- a/plugin/src/sbt-test/sbt-jni/simple/native/src/library.c
+++ b/plugin/src/sbt-test/sbt-jni/simple/native/src/library.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include "simple_Library__.h"
+#include "simple_Library_00024.h"
 
 /*
  * Class:     simple_Library__

--- a/plugin/src/sbt-test/sbt-jni/simple/test
+++ b/plugin/src/sbt-test/sbt-jni/simple/test
@@ -1,5 +1,5 @@
 > +javah
-$ exists native/src/include/simple_Library__.h
+$ exists native/src/include/simple_Library_00024.h
 > nativeInit cmake demo
 > +test
 > +core/run


### PR DESCRIPTION
Some extra context and thoughts can be found here: https://github.com/sbt/sbt-jni/pull/57
But in short: we don't need a special case for the `$` character: the only difference now would be in the generated filename that would also have an encoded `$` which makes filenames consistent with all generated method names.

Closes #36 