### PR TITLE
Add unmanagedPlatformDependentNativeDirectories

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/jni/util/CollectionOps.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/util/CollectionOps.scala
@@ -1,0 +1,27 @@
+package com.github.sbt.jni
+package util
+
+import scala.collection.IterableLike
+import scala.collection.generic.CanBuildFrom
+import scala.language.implicitConversions
+
+class CollectionOps[A, Repr](xs: IterableLike[A, Repr]) {
+  def distinctBy[B, That](f: A => B)(implicit cbf: CanBuildFrom[Repr, A, That]) = {
+    val builder = cbf(xs.repr)
+    val i = xs.iterator
+    var set = Set[B]()
+    while (i.hasNext) {
+      val o = i.next
+      val b = f(o)
+      if (!set(b)) {
+        set += b
+        builder += o
+      }
+    }
+    builder.result
+  }
+}
+
+object CollectionOps {
+  implicit def toCollectionOps[A, Repr](xs: IterableLike[A, Repr]) = new CollectionOps(xs)
+}


### PR DESCRIPTION
This PR adds ability to add unmanaged platform dependent directories. This can be extremely useful to simplify packaging of multi arch projects (i.e. in CI):

```scala
Compile / unmanagedPlatformDependentNativeDirectories := Seq(
  "x86_64-linux" -> target.value / "native/x86_64-linux/bin/",
  "x86_64-darwin" -> target.value / "native/x86_64-darwin/bin/"
)
```