### PR TITLE
Use JDK11 as the build JDK with target set to 1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [8]
+        java: [11]
         distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ val macrosParadiseVersion = "2.1.1"
 ThisBuild / versionScheme := Some("semver-spec")
 ThisBuild / organization := "com.github.sbt"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings")
+ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8") 
 ThisBuild / licenses := Seq(("BSD New", url("http://opensource.org/licenses/BSD-3-Clause")))
 ThisBuild / homepage := Some(url("https://github.com/jodersky/sbt-jni"))
 ThisBuild / developers := List(


### PR DESCRIPTION
This PR sets JDK 11 as the JDK version used for publish, however it also sets target to 1.8.
cc @sideeffffect