### PR TITLE
docs: fix typo breaking canonical use demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ This plugin packages native libraries produced by JniNative in a way that they c
      .dependsOn(native % Runtime) // remove this if `core` is a library, leave choice to end-user
 
    lazy val native = (project in file("myproject-native")) // native code and build script
-     .enablePlugin(JniNative) // JniNative needs to be explicitly enabled
+     .enablePlugins(JniNative) // JniNative needs to be explicitly enabled
    ```
    Note that separate projects are not strictly required. They are strongly recommended nevertheless, as a portability-convenience tradeoff: programs written in a JVM language are expected to run anywhere without recompilation, but including native libraries in jars limits this portability to only platforms of the packaged libraries. Having a separate native project enables the users to easily swap out the native library with their own implementation.
 


### PR DESCRIPTION
This PR would fix the bug in [canonical use](https://github.com/sbt/sbt-jni#canonical-use) with error logs sample as

```bash
[info] welcome to sbt 1.6.2 (Private Build Java 1.8.0_312)
[info] loading settings for project root-_sbt-canonical-use-build from plugins.sbt ...
[info] loading project definition from /github.com/sammyne/mastering-scala3/_sbt-canonical-use/project
/github.com/sammyne/mastering-scala3/_sbt-canonical-use/build.sbt:9: error: value enablePlugin is not a member of sbt.Project
possible cause: maybe a semicolon is missing before `value enablePlugin'?
    .enablePlugin(JniNative)
     ^
sbt.compiler.EvalException: Type error in expression
[error] sbt.compiler.EvalException: Type error in expression
[error] Use 'last' for the full log.
```