### PR TITLE
Fix sbt test on java 11

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
@@ -40,7 +40,9 @@ trait BuildTool {
 
       baseDirectory.mkdir()
       val out = baseDirectory.toPath().resolve(name)
-      Files.createDirectories(out.getParent)
+      if (!Files.isDirectory(out.getParent)) {
+        Files.createDirectories(out.getParent)
+      }
       Files.write(out, replaced.getBytes)
       out.toFile()
     }


### PR DESCRIPTION
Files.createDirectories throws a FileAlreadyExistsException exception when running `nativeInit cmake demo` on the oneproject sbt-test.