### PR TITLE
Enable building on Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import scala.sys.process._
 
-val scalaVersions = Seq("3.1.3", "2.13.8", "2.12.16")
+val scalaVersions = Seq("3.1.3", "2.13.8", "2.12.16", "2.11.12")
 val macrosParadiseVersion = "2.1.1"
 
 ThisBuild / versionScheme := Some("semver-spec")

--- a/core/src/main/scala/com/github/sbt/jni/syntax/NativeLoader.scala
+++ b/core/src/main/scala/com/github/sbt/jni/syntax/NativeLoader.scala
@@ -16,7 +16,7 @@ object NativeLoader {
       val plat: String = {
         val line =
           try {
-            scala.sys.process.Process("uname -sm").!!.linesIterator.next()
+            scala.io.Source.fromString(scala.sys.process.Process("uname -sm").!!).getLines().next()
           } catch {
             case _: Exception => sys.error("Error running `uname` command")
           }


### PR DESCRIPTION
I have an project that unfortunately is currently stuck on Scala 2.11. I'd like to be able to use this plugin. Fortunately, only a minor change was required to enable compilation on Scala 2.11 in addition to the existing targets.