### PR TITLE
Expose BuildTools parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ Source directory is set to `sourceDirectory.value` since the `CMake` project str
 │   ├── lib.cpp
 ```
 
+By default, `CMake` build is launched the following flags:
+
+* `-DCMAKE_BUILD_TYPE=Release` 
+* `-DSBT:BOOLEAN=true`
+
+It is possible to configure `CMake` by overriding the `nativeBuildTool` setting:
+
+```scala
+nativeBuildTool := CMake.make(Seq("-DCMAKE_BUILD_TYPE=Debug", "-DSBT:BOOLEAN=true"))
+```
+
 #### Cargo
 
 A regular `Cargo` native project definition usually looks this following way:
@@ -201,7 +212,7 @@ Source directory is set to `baseDirectory.value` since the `Cargo` project struc
 By default, `Cargo` build is launched with the `--release` flag. It is possible to configure `Cargo` profile by overriding the `nativeBuildTool` setting:
 
 ```scala
-nativeBuildTool := Cargo.make(release = false)
+nativeBuildTool := Cargo.make(Nil)
 ```
 
 ### JniPackage

--- a/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
@@ -83,7 +83,7 @@ trait BuildTool {
 
 object BuildTool {
   lazy val buildTools: Map[String, BuildTool] = Map(
-    CMake.name.toLowerCase -> CMake,
-    Cargo.release.name.toLowerCase -> Cargo.release
+    CMake.name.toLowerCase -> CMake.release,
+    Cargo.name.toLowerCase -> Cargo.release
   )
 }

--- a/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
@@ -40,7 +40,7 @@ object JniNative extends AutoPlugin {
     nativePlatform := {
       try {
         val lines = Process("uname -sm").lineStream
-        if (lines.length == 0) {
+        if (lines.isEmpty) {
           sys.error("Error occured trying to run `uname`")
         }
         // uname -sm returns "<kernel> <hardware name>"


### PR DESCRIPTION
This PR makes `CMake` and `Cargo` more flexible in terms of the passed configuration parameters.

I decided not to introduce new SBT Keys, but to use a similar pattern that was used for Cargo, which seems to be even more convenient.

Closes https://github.com/sbt/sbt-jni/issues/140

cc @berkeleybarry could you check how it works for you?