### PR TITLE
Add support of multiple native outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,16 @@ Since this plugin is basically a command-line wrapper, native build tools must f
 
 An initial, compatible build template can be obtained by running `sbt nativeInit <tool>`. Once the native build tool initialised, projects are built by calling the `sbt nativeCompile` task.
 
-Source and output directories are configurable
+Source and output directories are configurable:
 ```scala
 nativeCompile / sourceDirectory := sourceDirectory.value / "native"
 nativeCompile / target := target.value / "native" / nativePlatform.value
+```
+
+Some JNI projects may produce more than a single output. If that's an intended behavior it's possible to include all of the produced 
+binaries into the native package:
+```scala
+nativeMultipleOutputs := true
 ```
 
 #### CMake

--- a/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
@@ -79,6 +79,26 @@ trait BuildTool {
    */
   def getInstance(baseDirectory: File, buildDirectory: File, logger: Logger): Instance
 
+  /**
+   * At least one produced library is expected.
+   */
+  def validate(list: List[File], logger: Logger): List[File] = {
+    list match {
+      case Nil =>
+        sys.error(
+          s"No files were created during compilation, " +
+            s"something went wrong with the $name configuration."
+        )
+      case list @ _ :: Nil =>
+        list
+      case list =>
+        logger.info(
+          "More than one file was created during compilation: " +
+            s"${list.map(_.getAbsolutePath).mkString(", ")}."
+        )
+        list
+    }
+  }
 }
 
 object BuildTool {

--- a/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
@@ -92,10 +92,7 @@ trait BuildTool {
       case list @ _ :: Nil =>
         list
       case list =>
-        logger.info(
-          "More than one file was created during compilation: " +
-            s"${list.map(_.getAbsolutePath).mkString(", ")}."
-        )
+        logger.info("More than one file was created during compilation.")
         list
     }
   }

--- a/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
@@ -77,12 +77,12 @@ trait BuildTool {
   /**
    * Get an instance (build configuration) of this tool, in the specified directory.
    */
-  def getInstance(baseDirectory: File, buildDirectory: File, logger: Logger): Instance
+  def getInstance(baseDirectory: File, buildDirectory: File, logger: Logger, multipleOutputs: Boolean): Instance
 
   /**
    * At least one produced library is expected.
    */
-  def validate(list: List[File], logger: Logger): List[File] = {
+  def validate(list: List[File], multipleOutputs: Boolean, logger: Logger): List[File] = {
     list match {
       case Nil =>
         sys.error(
@@ -91,6 +91,16 @@ trait BuildTool {
         )
       case list @ _ :: Nil =>
         list
+
+      case head :: _ if !multipleOutputs =>
+        logger.warn(
+          s"""
+             |More than one file was created during compilation, only the first one (${head.getAbsolutePath}) will be used.
+             |Consider setting nativeMultipleOutputs := true.
+             |""".stripMargin
+        )
+        List(head)
+
       case list =>
         logger.info("More than one file was created during compilation.")
         list

--- a/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/BuildTool.scala
@@ -70,7 +70,7 @@ trait BuildTool {
      */
     def library(
       targetDirectory: File
-    ): File
+    ): List[File]
 
   }
 

--- a/plugin/src/main/scala/com/github/sbt/jni/build/CMake.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/CMake.scala
@@ -14,11 +14,12 @@ class CMake(protected val configuration: Seq[String]) extends BuildTool with Con
     "/com/github/sbt/jni/templates/CMakeLists.txt" -> "CMakeLists.txt"
   )
 
-  override def getInstance(baseDir: File, buildDir: File, logger: Logger) = new Instance {
+  override def getInstance(baseDir: File, buildDir: File, logger: Logger, nativeMultipleOutputs: Boolean) = new Instance {
 
     override def log = logger
     override def baseDirectory = baseDir
     override def buildDirectory = buildDir
+    override def multipleOutputs = nativeMultipleOutputs
 
     def cmakeProcess(args: String*): ProcessBuilder = Process("cmake" +: args, buildDirectory)
 

--- a/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
@@ -31,7 +31,7 @@ class Cargo(protected val configuration: Seq[String]) extends BuildTool {
 
     def clean(): Unit = Process("cargo clean", baseDirectory) ! log
 
-    def library(targetDirectory: File): File = {
+    def library(targetDirectory: File): List[File] = {
       val configurationString = (configuration ++ Seq("--target-dir", targetDirectory.getAbsolutePath)).mkString(" ").trim
       val ev =
         Process(
@@ -51,14 +51,14 @@ class Cargo(protected val configuration: Seq[String]) extends BuildTool {
             s"No files were created during compilation, " +
               s"something went wrong with the $name configuration."
           )
-        case head :: Nil =>
-          head
-        case head :: _ =>
+        case list @ _ :: Nil =>
+          list
+        case list =>
           logger.warn(
-            "More than one file was created during compilation, " +
-              s"only the first one (${head.getAbsolutePath}) will be used."
+            "More than one file was created during compilation: " +
+              s"${list.map(_.getAbsolutePath).mkString(", ")}."
           )
-          head
+          list
       }
     }
   }

--- a/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
@@ -44,22 +44,7 @@ class Cargo(protected val configuration: Seq[String]) extends BuildTool {
       val products: List[File] =
         (targetDirectory / subdir * ("*.so" | "*.dylib")).get.filter(_.isFile).toList
 
-      // only one produced library is expected
-      products match {
-        case Nil =>
-          sys.error(
-            s"No files were created during compilation, " +
-              s"something went wrong with the $name configuration."
-          )
-        case list @ _ :: Nil =>
-          list
-        case list =>
-          logger.warn(
-            "More than one file was created during compilation: " +
-              s"${list.map(_.getAbsolutePath).mkString(", ")}."
-          )
-          list
-      }
+      validate(products, logger)
     }
   }
 }

--- a/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
@@ -18,10 +18,10 @@ class Cargo(protected val configuration: Seq[String]) extends BuildTool {
 
   def release: Boolean = configuration.exists(_.toLowerCase.contains("release"))
 
-  def getInstance(baseDirectory: File, buildDirectory: File, logger: sbt.Logger): Instance =
-    new Instance(baseDirectory, logger)
+  def getInstance(baseDirectory: File, buildDirectory: File, logger: sbt.Logger, multipleOutputs: Boolean): Instance =
+    new Instance(baseDirectory, logger, multipleOutputs)
 
-  class Instance(protected val baseDirectory: File, protected val logger: sbt.Logger) extends super.Instance {
+  class Instance(protected val baseDirectory: File, protected val logger: sbt.Logger, protected val multipleOutputs: Boolean) extends super.Instance {
     // IntelliJ friendly logger, IntelliJ doesn't start tests if a line is printed as "error", which Cargo does for regular output
     protected val log: ProcessLogger = new ProcessLogger {
       def out(s: => String): Unit = logger.info(s)
@@ -44,7 +44,7 @@ class Cargo(protected val configuration: Seq[String]) extends BuildTool {
       val products: List[File] =
         (targetDirectory / subdir * ("*.so" | "*.dylib")).get.filter(_.isFile).toList
 
-      validate(products, logger)
+      validate(products, multipleOutputs, logger)
     }
   }
 }

--- a/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
@@ -25,7 +25,7 @@ trait ConfigureMakeInstall { self: BuildTool =>
 
     def library(
       targetDirectory: File
-    ): File = {
+    ): List[File] = {
 
       val ev: Int = (
         configure(targetDirectory) #&& make() #&& install()
@@ -43,14 +43,14 @@ trait ConfigureMakeInstall { self: BuildTool =>
             s"No files were created during compilation, " +
               s"something went wrong with the ${name} configuration."
           )
-        case head :: Nil =>
-          head
-        case head :: tail =>
+        case list @ _ :: Nil =>
+          list
+        case list =>
           log.warn(
-            "More than one file was created during compilation, " +
-              s"only the first one (${head.getAbsolutePath}) will be used."
+            "More than one file was created during compilation: " +
+              s"${list.map(_.getAbsolutePath).mkString(", ")}."
           )
-          head
+          list
       }
     }
   }

--- a/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
@@ -36,22 +36,7 @@ trait ConfigureMakeInstall { self: BuildTool =>
       val products: List[File] =
         (targetDirectory ** ("*.so" | "*.dylib")).get.filter(_.isFile).toList
 
-      // only one produced library is expected
-      products match {
-        case Nil =>
-          sys.error(
-            s"No files were created during compilation, " +
-              s"something went wrong with the ${name} configuration."
-          )
-        case list @ _ :: Nil =>
-          list
-        case list =>
-          log.warn(
-            "More than one file was created during compilation: " +
-              s"${list.map(_.getAbsolutePath).mkString(", ")}."
-          )
-          list
-      }
+      validate(products, log)
     }
   }
 

--- a/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
@@ -13,6 +13,7 @@ trait ConfigureMakeInstall { self: BuildTool =>
   trait Instance extends self.Instance {
 
     def log: Logger
+    def multipleOutputs: Boolean
     def baseDirectory: File
     def buildDirectory: File
 
@@ -36,7 +37,7 @@ trait ConfigureMakeInstall { self: BuildTool =>
       val products: List[File] =
         (targetDirectory ** ("*.so" | "*.dylib")).get.filter(_.isFile).toList
 
-      validate(products, log)
+      validate(products, multipleOutputs, log)
     }
   }
 

--- a/plugin/src/main/scala/com/github/sbt/jni/build/Meson.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/Meson.scala
@@ -15,11 +15,12 @@ class Meson(protected val configuration: Seq[String]) extends BuildTool with Con
     "/com/github/sbt/jni/templates/meson.options" -> "meson.options"
   )
 
-  override def getInstance(baseDir: File, buildDir: File, logger: Logger) = new Instance {
+  override def getInstance(baseDir: File, buildDir: File, logger: Logger, nativeMultipleOutputs: Boolean) = new Instance {
 
     override def log = logger
     override def baseDirectory = baseDir
     override def buildDirectory = buildDir
+    override def multipleOutputs = nativeMultipleOutputs
 
     def mesonProcess(args: String*): ProcessBuilder = Process("meson" +: args, buildDirectory)
 

--- a/plugin/src/main/scala/com/github/sbt/jni/build/Meson.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/Meson.scala
@@ -30,7 +30,7 @@ class Meson(protected val configuration: Seq[String]) extends BuildTool with Con
     override def configure(target: File) = {
       mesonProcess(
         Seq("setup", "--prefix", target.getAbsolutePath) ++ configuration ++ Seq(
-          mesonVersion.toString,
+          mesonVersion,
           baseDirectory.getAbsolutePath
         ): _*
       )

--- a/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
@@ -30,6 +30,10 @@ object JniNative extends AutoPlugin {
       "Initialize a native build script from a template."
     )
 
+    val nativeMultipleOutputs = taskKey[Boolean](
+      "Enable multiple native outputs support. Disabled by default."
+    )
+
   }
   import autoImport._
 
@@ -79,8 +83,8 @@ object JniNative extends AutoPlugin {
             tools.map(_.name).mkString(",")
         )
       )
-
     },
+    nativeMultipleOutputs := false,
     nativeBuildToolInstance := {
       val tool = nativeBuildTool.value
       val srcDir = (nativeCompile / sourceDirectory).value
@@ -89,7 +93,8 @@ object JniNative extends AutoPlugin {
       tool.getInstance(
         baseDirectory = srcDir,
         buildDirectory = buildDir,
-        logger = streams.value.log
+        logger = streams.value.log,
+        multipleOutputs = nativeMultipleOutputs.value
       )
     },
     nativeCompile / clean := {

--- a/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
@@ -14,7 +14,7 @@ object JniNative extends AutoPlugin {
   object autoImport {
 
     // Main task, inspect this first
-    val nativeCompile = taskKey[File](
+    val nativeCompile = taskKey[Seq[File]](
       "Builds a native library by calling the native build tool."
     )
 
@@ -114,9 +114,9 @@ object JniNative extends AutoPlugin {
       IO.createDirectory(targetDir)
 
       log.info(s"Building library with native build tool ${tool.name}")
-      val lib = toolInstance.library(targetDir)
-      log.success(s"Library built in ${lib.getAbsolutePath}")
-      lib
+      val libs = toolInstance.library(targetDir)
+      log.success(s"Libraries built in ${libs.map(_.getAbsolutePath).mkString(", ")}")
+      libs
     },
 
     // also clean native sources

--- a/plugin/src/main/scala/com/github/sbt/jni/plugins/JniPackage.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/plugins/JniPackage.scala
@@ -74,10 +74,8 @@ object JniPackage extends AutoPlugin {
       .taskDyn[Seq[(File, String)]] {
         val enableManaged = enableNativeCompilation.value
         if (enableManaged) Def.task {
-          val library: File = nativeCompile.value
           val platform = nativePlatform.value
-
-          Seq(library -> s"/native/$platform/${library.name}")
+          nativeCompile.value.map { library => library -> s"/native/$platform/${library.name}" }
         }
         else
           Def.task {


### PR DESCRIPTION
This PR modifies all build tools behavior to put all the possible project outputs into the res artifact. 

See https://github.com/sbt/sbt-jni/issues/185#issuecomment-1832150228

Closes https://github.com/sbt/sbt-jni/issues/185

@datben could you check if it works for you?

I'll try it on my repos as well later to ensure that nothing is broken with this change.