### PR TITLE
Drop JDK8 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        java: [8, 11, 17]
+        java: [11, 17, 21]
         distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:
@@ -26,7 +26,15 @@ jobs:
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
+      
+      - run: brew install sbt
+        if: ${{ matrix.os == 'macos-latest' }}
+
+      - run: python3 -m pip install --break-system-packages meson ninja
+        if: ${{ matrix.os == 'macos-latest' }}
+      
       - run: python3 -m pip install meson ninja
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Check formatting
         run: sbt scalafmtCheckAll
@@ -41,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [8]
+        java: [11]
         distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import scala.sys.process._
 
-val scalaVersions = Seq("3.4.1", "2.13.13", "2.12.19", "2.11.12")
+val scalaVersions = Seq("3.4.1", "2.13.14", "2.12.19", "2.11.12")
 val macrosParadiseVersion = "2.1.1"
 
 ThisBuild / versionScheme := Some("semver-spec")

--- a/plugin/src/sbt-test/sbt-jni/overloads/project/ScriptedHelper.scala
+++ b/plugin/src/sbt-test/sbt-jni/overloads/project/ScriptedHelper.scala
@@ -8,7 +8,7 @@ object ScriptedHelper extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalacOptions ++= Seq("-feature", "-deprecation"),
-    crossScalaVersions := Seq("2.13.13", "2.12.14"),
+    crossScalaVersions := Seq("2.13.14", "2.12.19"),
     scalaVersion := crossScalaVersions.value.head
   )
 

--- a/plugin/src/sbt-test/sbt-jni/overloads/project/build.properties
+++ b/plugin/src/sbt-test/sbt-jni/overloads/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+../../simple/project/build.properties

--- a/plugin/src/sbt-test/sbt-jni/simple-cargo/project/ScriptedHelper.scala
+++ b/plugin/src/sbt-test/sbt-jni/simple-cargo/project/ScriptedHelper.scala
@@ -8,7 +8,7 @@ object ScriptedHelper extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalacOptions ++= Seq("-feature", "-deprecation"),
-    crossScalaVersions := Seq("2.13.13", "2.12.19"),
+    crossScalaVersions := Seq("2.13.14", "2.12.19"),
     scalaVersion := crossScalaVersions.value.head
   )
 

--- a/plugin/src/sbt-test/sbt-jni/simple-cargo/project/build.properties
+++ b/plugin/src/sbt-test/sbt-jni/simple-cargo/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+../../simple/project/build.properties

--- a/plugin/src/sbt-test/sbt-jni/simple-meson/project/ScriptedHelper.scala
+++ b/plugin/src/sbt-test/sbt-jni/simple-meson/project/ScriptedHelper.scala
@@ -8,7 +8,7 @@ object ScriptedHelper extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalacOptions ++= Seq("-feature", "-deprecation"),
-    crossScalaVersions := Seq("2.13.13", "2.12.19"),
+    crossScalaVersions := Seq("2.13.14", "2.12.19"),
     scalaVersion := crossScalaVersions.value.head
   )
 

--- a/plugin/src/sbt-test/sbt-jni/simple-meson/project/build.properties
+++ b/plugin/src/sbt-test/sbt-jni/simple-meson/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+../../simple/project/build.properties

--- a/plugin/src/sbt-test/sbt-jni/simple-syntax/project/ScriptedHelper.scala
+++ b/plugin/src/sbt-test/sbt-jni/simple-syntax/project/ScriptedHelper.scala
@@ -8,7 +8,7 @@ object ScriptedHelper extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalacOptions ++= Seq("-feature", "-deprecation"),
-    crossScalaVersions := Seq("3.4.1", "2.13.13", "2.12.19"),
+    crossScalaVersions := Seq("3.4.1", "2.13.14", "2.12.19"),
     scalaVersion := crossScalaVersions.value.head
   )
 

--- a/plugin/src/sbt-test/sbt-jni/simple-syntax/project/build.properties
+++ b/plugin/src/sbt-test/sbt-jni/simple-syntax/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+../../simple/project/build.properties

--- a/plugin/src/sbt-test/sbt-jni/simple/project/ScriptedHelper.scala
+++ b/plugin/src/sbt-test/sbt-jni/simple/project/ScriptedHelper.scala
@@ -8,7 +8,7 @@ object ScriptedHelper extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalacOptions ++= Seq("-feature", "-deprecation"),
-    crossScalaVersions := Seq("2.13.13", "2.12.19"),
+    crossScalaVersions := Seq("2.13.14", "2.12.19"),
     scalaVersion := crossScalaVersions.value.head
   )
 

--- a/plugin/src/sbt-test/sbt-jni/simple/project/build.properties
+++ b/plugin/src/sbt-test/sbt-jni/simple/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0


### PR DESCRIPTION
There are two solutions: switch to zulu or drop jdk8. I think it's time to let it go.

Closes #203
Closes #202
Closes #201