### PR TITLE
Fix DLL not found on Windows

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/Cargo.scala
@@ -42,7 +42,7 @@ class Cargo(protected val configuration: Seq[String]) extends BuildTool {
 
       val subdir = if (release) "release" else "debug"
       val products: List[File] =
-        (targetDirectory / subdir * ("*.so" | "*.dylib")).get().filter(_.isFile).toList
+        (targetDirectory / subdir * ("*.so" | "*.dylib" | "*.dll")).get().filter(_.isFile).toList
 
       validate(products, multipleOutputs, logger)
     }

--- a/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/build/ConfigureMakeInstall.scala
@@ -35,7 +35,7 @@ trait ConfigureMakeInstall { self: BuildTool =>
       if (ev != 0) sys.error(s"Building native library failed. Exit code: ${ev}")
 
       val products: List[File] =
-        (targetDirectory ** ("*.so" | "*.dylib")).get.filter(_.isFile).toList
+        (targetDirectory ** ("*.so" | "*.dylib" | "*.dll")).get.filter(_.isFile).toList
 
       validate(products, multipleOutputs, log)
     }


### PR DESCRIPTION
As mentioned in https://github.com/sbt/sbt-jni/issues/20#issuecomment-2564520809 there was an issue when building on Windows (using MinGW). Cargo would produce a DLL file, but sbt-jni could not find it. This PR fixes that issue for all three build tools.

I have run the sbt-tests on a Windows computer. Most tests failed (expected on Windows), but at least the "simple-cargo" test succeded. That means that the file was found and the Scala code was able to call the Rust function.