### PR TITLE
Remove dependency on `uname` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ nativeBuildTool := Meson.make(Nil)
 |--------------------------------|---------------|
 | automatic, when JniNative enabled | [JniPackage.scala](plugin/src/main/scala/com/github/sbt/jni/plugins/JniPackage.scala) |
 
-This plugin packages native libraries produced by JniNative in a way that they can be transparently loaded with JniLoad. It uses the notion of a native "platform", defined as the architecture-kernel values returned by `uname -sm`. A native binary of a given platform is assumed to be executable on any machines of the same platform.
+This plugin packages native libraries produced by JniNative in a way that they can be transparently loaded with JniLoad. It uses the notion of a native "platform", defined using the `os.name` and `os.arch` properties. A native binary of a given platform is assumed to be executable on any machines of the same platform.
 
 ## Canonical Use
 
@@ -325,7 +325,7 @@ Real-world use-cases of sbt-jni include:
 
 - projects using `JniLoad` must use Scala versions 2.11, 2.12, 2.13 or 3.2
   - projects using `JniLoad` with Scala 3 should use it with the `sbtJniCoreScope := Compile` SBT key set
-- only POSIX platforms are supported (actually, any platform that has the `uname` command available)
+- only POSIX platforms are supported
 
 The goal of sbt-jni is to be the least intrusive possible. No transitive dependencies are added to projects using any plugin (some dependencies are added to the `provided` configuration, however these do not affect any downstream projects).
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ nativeBuildTool := Meson.make(Nil)
 |--------------------------------|---------------|
 | automatic, when JniNative enabled | [JniPackage.scala](plugin/src/main/scala/com/github/sbt/jni/plugins/JniPackage.scala) |
 
-This plugin packages native libraries produced by JniNative in a way that they can be transparently loaded with JniLoad. It uses the notion of a native "platform", defined using the `os.name` and `os.arch` properties. A native binary of a given platform is assumed to be executable on any machines of the same platform.
+This plugin packages native libraries produced by JniNative in a way that they can be transparently loaded with JniLoad. It uses the notion of a native "platform", defined as the architecture-kernel values returned by `uname -sm`, or using the `os.name` and `os.arch` properties if the `uname` command is not available. A native binary of a given platform is assumed to be executable on any machines of the same platform.
 
 ## Canonical Use
 

--- a/core/src/main/scala-2/com/github/sbt/jni/annotations.scala
+++ b/core/src/main/scala-2/com/github/sbt/jni/annotations.scala
@@ -73,18 +73,36 @@ class nativeLoaderAnnotationMacro(val c: Context) {
             }
 
             def determinePlatform(): (String, String) = {
-              val os = System.getProperty("os.name").toLowerCase match {
-                case s if s.contains("win") => "windows"
-                case s if s.contains("mac") => "darwin"
-                case _                      => "linux"
-              }
+              try {
+                val line =
+                  try {
+                    scala.io.Source.fromString(scala.sys.process.Process("uname -sm").!!).getLines().next()
+                  } catch {
+                    case _: Exception => sys.error("Error running `uname` command")
+                  }
+                val parts = line.split(" ")
+                if (parts.length != 2) {
+                  sys.error("Could not determine platform: 'uname -sm' returned unexpected string: " + line)
+                } else {
+                  val arch = parts(1).toLowerCase.replaceAll("\\s", "")
+                  val kernel = parts(0).toLowerCase.replaceAll("\\s", "")
+                  (arch, kernel)
+                }
+              } catch {
+                case _: Exception =>
+                  val os = System.getProperty("os.name").toLowerCase match {
+                    case s if s.contains("win") => "windows"
+                    case s if s.contains("mac") => "darwin"
+                    case _                      => "linux"
+                  }
 
-              val arch = System.getProperty("os.arch").toLowerCase match {
-                case "arm64" | "aarch64" => "arm64"
-                case _                   => "x86_64"
-              }
+                  val arch = System.getProperty("os.arch").toLowerCase match {
+                    case "arm64" | "aarch64" => "arm64"
+                    case _                   => "x86_64"
+                  }
 
-              (os, arch)
+                  (os, arch)
+              }
             }
 
             load()

--- a/core/src/main/scala/com/github/sbt/jni/syntax/NativeLoader.scala
+++ b/core/src/main/scala/com/github/sbt/jni/syntax/NativeLoader.scala
@@ -45,18 +45,36 @@ object NativeLoader {
     }
 
     def determinePlatform(): (String, String) = {
-      val os = System.getProperty("os.name").toLowerCase match {
-        case s if s.contains("win") => "windows"
-        case s if s.contains("mac") => "darwin"
-        case _                      => "linux"
-      }
+      try {
+        val line =
+          try {
+            scala.io.Source.fromString(scala.sys.process.Process("uname -sm").!!).getLines().next()
+          } catch {
+            case _: Exception => sys.error("Error running `uname` command")
+          }
+        val parts = line.split(" ")
+        if (parts.length != 2) {
+          sys.error("Could not determine platform: 'uname -sm' returned unexpected string: " + line)
+        } else {
+          val arch = parts(1).toLowerCase.replaceAll("\\s", "")
+          val kernel = parts(0).toLowerCase.replaceAll("\\s", "")
+          (arch, kernel)
+        }
+      } catch {
+        case _: Exception =>
+          val os = System.getProperty("os.name").toLowerCase match {
+            case s if s.contains("win") => "windows"
+            case s if s.contains("mac") => "darwin"
+            case _                      => "linux"
+          }
 
-      val arch = System.getProperty("os.arch").toLowerCase match {
-        case "arm64" | "aarch64" => "arm64"
-        case _                   => "x86_64"
-      }
+          val arch = System.getProperty("os.arch").toLowerCase match {
+            case "arm64" | "aarch64" => "arm64"
+            case _                   => "x86_64"
+          }
 
-      (os, arch)
+          (os, arch)
+      }
     }
 
     load()

--- a/core/src/main/scala/com/github/sbt/jni/syntax/NativeLoader.scala
+++ b/core/src/main/scala/com/github/sbt/jni/syntax/NativeLoader.scala
@@ -14,20 +14,8 @@ object NativeLoader {
 
       val tmp: Path = Files.createTempDirectory("jni-")
       val plat: String = {
-        val line =
-          try {
-            scala.io.Source.fromString(scala.sys.process.Process("uname -sm").!!).getLines().next()
-          } catch {
-            case _: Exception => sys.error("Error running `uname` command")
-          }
-        val parts = line.split(" ")
-        if (parts.length != 2) {
-          sys.error("Could not determine platform: 'uname -sm' returned unexpected string: " + line)
-        } else {
-          val arch = parts(1).toLowerCase.replaceAll("\\s", "")
-          val kernel = parts(0).toLowerCase.replaceAll("\\s", "")
-          arch + "-" + kernel
-        }
+        val (kernel, arch) = determinePlatform()
+        arch + "-" + kernel
       }
 
       val resourcePath: String = "/native/" + plat + "/" + lib
@@ -54,6 +42,21 @@ object NativeLoader {
       System.loadLibrary(nativeLibrary)
     } catch {
       case _: UnsatisfiedLinkError => loadPackaged()
+    }
+
+    def determinePlatform(): (String, String) = {
+      val os = System.getProperty("os.name").toLowerCase match {
+        case s if s.contains("win") => "windows"
+        case s if s.contains("mac") => "darwin"
+        case _                      => "linux"
+      }
+
+      val arch = System.getProperty("os.arch").toLowerCase match {
+        case "arm64" | "aarch64" => "arm64"
+        case _                   => "x86_64"
+      }
+
+      (os, arch)
     }
 
     load()

--- a/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
+++ b/plugin/src/main/scala/com/github/sbt/jni/plugins/JniNative.scala
@@ -145,18 +145,36 @@ object JniNative extends AutoPlugin {
   )
 
   private def determinePlatform(): (String, String) = {
-    val os = System.getProperty("os.name").toLowerCase match {
-      case s if s.contains("win") => "windows"
-      case s if s.contains("mac") => "darwin"
-      case _                      => "linux"
-    }
+    try {
+      val line =
+        try {
+          scala.io.Source.fromString(scala.sys.process.Process("uname -sm").!!).getLines().next()
+        } catch {
+          case _: Exception => sys.error("Error running `uname` command")
+        }
+      val parts = line.split(" ")
+      if (parts.length != 2) {
+        sys.error("Could not determine platform: 'uname -sm' returned unexpected string: " + line)
+      } else {
+        val arch = parts(1).toLowerCase.replaceAll("\\s", "")
+        val kernel = parts(0).toLowerCase.replaceAll("\\s", "")
+        (arch, kernel)
+      }
+    } catch {
+      case _: Exception =>
+        val os = System.getProperty("os.name").toLowerCase match {
+          case s if s.contains("win") => "windows"
+          case s if s.contains("mac") => "darwin"
+          case _                      => "linux"
+        }
 
-    val arch = System.getProperty("os.arch").toLowerCase match {
-      case "arm64" | "aarch64" => "arm64"
-      case _                   => "x86_64"
-    }
+        val arch = System.getProperty("os.arch").toLowerCase match {
+          case "arm64" | "aarch64" => "arm64"
+          case _                   => "x86_64"
+        }
 
-    (os, arch)
+        (os, arch)
+    }
   }
 
   override lazy val projectSettings = settings


### PR DESCRIPTION
As mentioned in https://github.com/sbt/sbt-jni/issues/20 the `uname` command does not exist on Windows, which means that a program built using `sbt-jni` cannot be run on Windows.

This PR removes all usages of the `uname` command from `sbt-jni` so that it becomes platform independent.

I have verified that the updated `NativeLoader` works on linux, mac and windows.

Note: this does not mean that the `sbt-jni` plugin works on Windows (I haven't checked). It only means that the code used to load the native library works there.